### PR TITLE
Add: fix deploy prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,5 +27,5 @@ jobs:
 
           IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:${IMAGE_TAG}"
 
-          docker build -t "${IMAGE_NAME}" .
+          docker build -f docker/prod.Dockerfile -t "${IMAGE_NAME}" .
           docker push "${IMAGE_NAME}"


### PR DESCRIPTION
This pull request includes a small but important change to the deployment workflow configuration. The change specifies a different Dockerfile for the production build.

    .github/workflows/deploy-prod.yml: Modified the docker build command to use docker/prod.Dockerfile instead of the default Dockerfile.